### PR TITLE
Publish release artifact on tag push

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -9,8 +9,6 @@ on:
 jobs:
     build:
         runs-on: ubuntu-latest
-        env:
-            VERSION_PATTERN: 1.0
         steps:
             - name: Checkout
               uses: actions/checkout@v2
@@ -18,8 +16,10 @@ jobs:
                   submodules: true
             - name: Calculate version
               run: |
-                VERSION=`[[ $GITHUB_REF == refs/tags/* ]] && echo $GITHUB_REF | cut -d / -f 3 || echo $VERSION_PATTERN.${{ github.run_id }}`
-                echo "Version detected: $VERSION"
+                VERSION=`[[ $GITHUB_REF == refs/tags/* ]] \
+                  && echo $GITHUB_REF | cut -d / -f 3 \
+                  || echo $(jq -r .version package.json).${{ github.run_id }}`
+                echo "Version used: $VERSION"
                 echo "::set-env name=JETBRAINS_VERSION::$VERSION"
             - name: Install Node.js
               uses: actions/setup-node@v1

--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -3,10 +3,14 @@ on:
     push:
         branches:
             - master
+        tags:
+            - '*'
 
 jobs:
     build:
         runs-on: ubuntu-latest
+        env:
+            VERSION: 1.0.${{ github.run_id }}
         steps:
             - name: Checkout
               uses: actions/checkout@v2
@@ -16,8 +20,32 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: 10.x
-            - run: ./gradlew publish -Pversion=1.0.${{ github.run_id }}
+            - run: ./gradlew publish -Pversion=${{ env.VERSION }}
             - name: Upload build artifact
               uses: actions/upload-artifact@v2
               with:
                   path: "build/repo/**/*"
+
+            # Publish Release
+            - name: Create ZIP file
+              if: startsWith(github.ref, 'refs/tags/')
+              run: cd ./build/repo && zip -r $GITHUB_WORKSPACE/rider-debug-visualizer-web-${{ env.VERSION }}.zip *
+            - name: Create Release
+              if: startsWith(github.ref, 'refs/tags/')
+              id: create_release
+              uses: actions/create-release@v1
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  tag_name: ${{ github.ref }}
+                  release_name: Release ${{ github.ref }}
+            - name: Upload Release Asset
+              if: startsWith(github.ref, 'refs/tags/')
+              uses: actions/upload-release-asset@v1
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  upload_url: ${{ steps.create_release.outputs.upload_url }}
+                  asset_path: ./rider-debug-visualizer-web-${{ env.VERSION }}.zip
+                  asset_name: rider-debug-visualizer-web-${{ env.VERSION }}.zip
+                  asset_content_type: application/zip

--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -10,17 +10,22 @@ jobs:
     build:
         runs-on: ubuntu-latest
         env:
-            VERSION: 1.0.${{ github.run_id }}
+            VERSION_PATTERN: 1.0
         steps:
             - name: Checkout
               uses: actions/checkout@v2
               with:
                   submodules: true
+            - name: Calculate version
+              run: |
+                VERSION=`[[ $GITHUB_REF == refs/tags/* ]] && echo $GITHUB_REF | cut -d / -f 3 || echo $VERSION_PATTERN.${{ github.run_id }}`
+                echo "Version detected: $VERSION"
+                echo "::set-env name=JETBRAINS_VERSION::$VERSION"
             - name: Install Node.js
               uses: actions/setup-node@v1
               with:
                   node-version: 10.x
-            - run: ./gradlew publish -Pversion=${{ env.VERSION }}
+            - run: ./gradlew publish -Pversion=$JETBRAINS_VERSION
             - name: Upload build artifact
               uses: actions/upload-artifact@v2
               with:
@@ -29,7 +34,7 @@ jobs:
             # Publish Release
             - name: Create ZIP file
               if: startsWith(github.ref, 'refs/tags/')
-              run: cd ./build/repo && zip -r $GITHUB_WORKSPACE/rider-debug-visualizer-web-${{ env.VERSION }}.zip *
+              run: cd ./build/repo && zip -r $GITHUB_WORKSPACE/rider-debug-visualizer-web-$JETBRAINS_VERSION.zip *
             - name: Create Release
               if: startsWith(github.ref, 'refs/tags/')
               id: create_release
@@ -38,7 +43,7 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
                   tag_name: ${{ github.ref }}
-                  release_name: Release ${{ github.ref }}
+                  release_name: v${{ github.ref }}
             - name: Upload Release Asset
               if: startsWith(github.ref, 'refs/tags/')
               uses: actions/upload-release-asset@v1
@@ -46,6 +51,6 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
                   upload_url: ${{ steps.create_release.outputs.upload_url }}
-                  asset_path: ./rider-debug-visualizer-web-${{ env.VERSION }}.zip
-                  asset_name: rider-debug-visualizer-web-${{ env.VERSION }}.zip
+                  asset_path: ./rider-debug-visualizer-web-${{ env.JETBRAINS_VERSION }}.zip
+                  asset_name: rider-debug-visualizer-web-${{ env.JETBRAINS_VERSION }}.zip
                   asset_content_type: application/zip


### PR DESCRIPTION
This will create GitHub releases based on our tags. It expects tags to have plain version number in them. For example, a tag `1.0.0` will be published as release `v1.0.0`.

For intermediate builds, version will be generated as `$JSON_VERSION.${{ github.run_id }}` (where `$JSON_VERSION` is read from the `package.json`).

So, when preparing a release, you're supposed to push a tag `1.0.0` into the repository (and remove it and push again if you want to re-run the publishing). After that, a release will be created on the [Releases page](https://github.com/JetBrains/rider-debug-visualizer-web-view/releases) from this tag.